### PR TITLE
feat: upload files directly when full size

### DIFF
--- a/apps/docs/examples/common/PreviewFile.tsx
+++ b/apps/docs/examples/common/PreviewFile.tsx
@@ -19,6 +19,11 @@ export const PreviewFile = (props: {
     src = file.url;
   } else if (file.status === 'cropped') {
     src = file.thumbData;
+  } else if (file.status === 'notCropped') {
+    // with the component cropped but full size
+    src = file.previewUrl;
+  } else {
+    src = file.previewUrl;
   }
   
   src = src || file.previewUrl;

--- a/apps/docs/examples/common/PreviewFile.tsx
+++ b/apps/docs/examples/common/PreviewFile.tsx
@@ -12,17 +12,17 @@ export const PreviewFile = (props: {
 }) => {
   const { file } = props;
 
-  let src: string;
+  let src: string = '';
   if (file.status === 'uploading') {
     src = file.thumbData || file.imageData;
   } else if (file.status === 'done') {
     src = file.url;
   } else if (file.status === 'cropped') {
     src = file.thumbData;
-  } else {
-    src = file.previewUrl;
   }
-
+  
+  src = src || file.previewUrl;
+ 
   return (
     <>
       <Img3 style={{ maxHeight: '100%', maxWidth: '100%' }} src={src} alt={file.name} />

--- a/apps/docs/pages/components/Uploader3.mdx
+++ b/apps/docs/pages/components/Uploader3.mdx
@@ -80,9 +80,7 @@ Uploader3 children component has the ability to click and drag to select files.
 
 ### Support svg file
 
-Set `accept` to `['.svg']` to support svg file.
-
-However, `svg` is a vector image and does not support cropping. Please turn off the `crop` option at the same time.
+Set `accept` to `['.svg']` only pick svg files, and turn off cropping
 
 
 <Playground title={'Only svg file - @lxdao/uploader3'} files={uploader3Examples.onlySvg} />
@@ -98,6 +96,8 @@ const defaultCropOptions = {
   aspectRatio: 1,
 };
 ```
+
+If you choose a `.svg` file and want to keep the file format and upload it directly, you can adjust the cropping ratio to `full`.
 
 <Playground title={'Single file - @lxdao/uploader3'} files={uploader3Examples.single} />
 

--- a/apps/docs/pages/components/Uploader3.mdx
+++ b/apps/docs/pages/components/Uploader3.mdx
@@ -20,20 +20,20 @@ import { Uploader3 } from '@lxdao/uploader3';
 
 ## Props
 
-| Prop           | Type                        | Description                                            | Default                          |
-| -------------- | --------------------------- | ------------------------------------------------------ | -------------------------------- |
-| accept         | `string`                    | image accept file type                                 | `['.png','.jpeg','.jpg','.gif']` |
-| multiple       | `boolean`                   | multiple image upload                                  | `false`                          |
-| api            | `string`                    | endpoint upload api url, post method                   |                                  |
-| headers        | `object`                    | http headers to post api                               |                                  |
-| responseFormat | `function`                  | response data format                                   |                                  |
-| connector      | `object`                    | create by [uploader3-connector](./uploader3-connector) |                                  |
-| crop           | [`Crop`](#crop) / `boolean` | crop config, set `false` disabled crop                 | `true`                           |
-| onChange       | `function`                  | callback when files selected                           |                                  |
-| onUpload       | `function`                  | callback when file uploading                           |                                  |
-| onComplete     | `function`                  | callback when file uploaded                            |                                  |
-| onCropEnd      | `function`                  | callback when crop end                                 |                                  |
-| onCropCancel   | `function`                  | callback when crop cancel                              |                                  |
+| Prop           | Type                        | Description                                            | Default                                  |
+| -------------- | --------------------------- | ------------------------------------------------------ | ---------------------------------------- |
+| accept         | `string`                    | image accept file type                                 | `['.png','.jpeg','.jpg','.gif', '.svg']` |
+| multiple       | `boolean`                   | multiple image upload                                  | `false`                                  |
+| api            | `string`                    | endpoint upload api url, post method                   |                                          |
+| headers        | `object`                    | http headers to post api                               |                                          |
+| responseFormat | `function`                  | response data format                                   |                                          |
+| connector      | `object`                    | create by [uploader3-connector](./uploader3-connector) |                                          |
+| crop           | [`Crop`](#crop) / `boolean` | crop config, set `false` disabled crop                 | `true`                                   |
+| onChange       | `function`                  | callback when files selected                           |                                          |
+| onUpload       | `function`                  | callback when file uploading                           |                                          |
+| onComplete     | `function`                  | callback when file uploaded                            |                                          |
+| onCropEnd      | `function`                  | callback when crop end                                 |                                          |
+| onCropCancel   | `function`                  | callback when crop cancel                              |                                          |
 
 ### api
 
@@ -82,9 +82,7 @@ Uploader3 children component has the ability to click and drag to select files.
 
 Set `accept` to `['.svg']` only pick svg files, and turn off cropping
 
-
 <Playground title={'Only svg file - @lxdao/uploader3'} files={uploader3Examples.onlySvg} />
-
 
 ### Single file
 

--- a/apps/docs/theme.config.jsx
+++ b/apps/docs/theme.config.jsx
@@ -9,7 +9,6 @@ export default {
   darkMode: false,
   nextThemes: {
     defaultTheme: 'light',
-    enableSystem: false,
   },
   docsRepositoryBase: 'https://github.com/lxdao-official/Img3/blob/apps/docs/',
   project: {

--- a/apps/web/components/PreviewFile.tsx
+++ b/apps/web/components/PreviewFile.tsx
@@ -10,16 +10,16 @@ export const PreviewFile = (props: {
 }) => {
   const { file } = props;
 
-  let src: string;
+  let src: string = '';
   if (file.status === 'uploading') {
     src = file.thumbData || file.imageData;
   } else if (file.status === 'done') {
     src = file.url;
   } else if (file.status === 'cropped') {
     src = file.thumbData;
-  } else {
-    src = file.previewUrl;
   }
+
+  src = src || file.previewUrl;
 
   return (
     <>

--- a/apps/web/components/PreviewFile.tsx
+++ b/apps/web/components/PreviewFile.tsx
@@ -17,9 +17,12 @@ export const PreviewFile = (props: {
     src = file.url;
   } else if (file.status === 'cropped') {
     src = file.thumbData;
+  } else if (file.status === 'notCropped') {
+    // with the component cropped but full size
+    src = file.previewUrl;
+  } else {
+    src = file.previewUrl;
   }
-
-  src = src || file.previewUrl;
 
   return (
     <>

--- a/apps/web/pages/cropp/index.tsx
+++ b/apps/web/pages/cropp/index.tsx
@@ -14,6 +14,7 @@ export default function Demo() {
         aspectRatio={1}
         fileType={'image/png'}
         fileUrl={'https://raw.githubusercontent.com/lxdao-official/Img3/test/uploader3/apps/docs/public/img3.png'}
+        fileName={'img3.png'}
         size={{ width: '300px', height: '300px' }}
         onConfirm={(data) => {
           console.log(data);

--- a/packages/uploader3/README.md
+++ b/packages/uploader3/README.md
@@ -18,19 +18,19 @@ import { Uploader3 } from '@lxdao/uploader3';
 
 ## Props
 
-| Prop         | Type                        | Description                            | Default                          |
-| ------------ | --------------------------- | -------------------------------------- | -------------------------------- |
-| accept       | `string`                    | image accept file type                 | `['.png','.jpeg','.jpg','.gif']` |
-| multiple     | `boolean`                   | multiple image upload                  | `false`                          |
-| api          | `string`                    | endpoint upload api url, post method   | `''`                             |
-| headers      | `object`                    | http headers to post api               |                                  |
-| connector    | `object`                    | create by uploader3-connector          |                                  |
-| crop         | [`Crop`](#crop) / `boolean` | crop config, set `false` disabled crop | `true`                           |
-| onChange     | `function`                  | callback when files selected           |                                  |
-| onUpload     | `function`                  | callback when file uploading           |                                  |
-| onComplete   | `function`                  | callback when file uploaded            |                                  |
-| onCropEnd    | `function`                  | callback when crop end                 |                                  |
-| onCropCancel | `function`                  | callback when crop cancel              |                                  |
+| Prop         | Type                        | Description                            | Default                                  |
+| ------------ | --------------------------- | -------------------------------------- | ---------------------------------------- |
+| accept       | `string`                    | image accept file type                 | `['.png','.jpeg','.jpg','.gif', '.svg']` |
+| multiple     | `boolean`                   | multiple image upload                  | `false`                                  |
+| api          | `string`                    | endpoint upload api url, post method   | `''`                                     |
+| headers      | `object`                    | http headers to post api               |                                          |
+| connector    | `object`                    | create by uploader3-connector          |                                          |
+| crop         | [`Crop`](#crop) / `boolean` | crop config, set `false` disabled crop | `true`                                   |
+| onChange     | `function`                  | callback when files selected           |                                          |
+| onUpload     | `function`                  | callback when file uploading           |                                          |
+| onComplete   | `function`                  | callback when file uploaded            |                                          |
+| onCropEnd    | `function`                  | callback when crop end                 |                                          |
+| onCropCancel | `function`                  | callback when crop cancel              |                                          |
 
 > `api` and `connector` are mutually exclusive, if both are provided, `api` will be used. must be provided one of them.
 

--- a/packages/uploader3/src/Uploader3.tsx
+++ b/packages/uploader3/src/Uploader3.tsx
@@ -8,6 +8,7 @@ import { useFiles } from './useEditFile';
 
 import type { Uploader3Connector } from '@lxdao/uploader3-connector';
 import type { CroppedFile, SelectedFile, SelectedFiles, Uploader3Props } from './types';
+import { Uploader3FileStatus } from './types';
 import { acceptToMime } from './acceptToMime';
 
 const Wrapper = styled.div`
@@ -20,7 +21,14 @@ const createCroppedFile = (
   file: SelectedFile,
   croppAttributes: Pick<CroppedFile, 'imageData' | 'thumbData' | 'crop'>
 ): CroppedFile => {
-  return { ...file, ...croppAttributes, status: 'cropped' };
+  const { imageData, thumbData, crop } = croppAttributes;
+  let status = Uploader3FileStatus.cropped;
+  // is full size
+  if (!crop) {
+    status = Uploader3FileStatus.notCropped;
+  }
+
+  return { ...file, imageData, thumbData, crop, status };
 };
 
 const defaultCropOptions = {
@@ -102,15 +110,15 @@ export const Uploader3: React.FC<React.PropsWithChildren<Uploader3Props>> = ({
 
                 const { url } = responseData;
 
-                curFile = { ...curFile, status: 'done', url };
+                curFile = { ...curFile, status: Uploader3FileStatus.done, url };
               } else {
                 const { message } = await res.json();
-                curFile = { ...curFile, status: 'error', message };
+                curFile = { ...curFile, status: Uploader3FileStatus.error, message };
               }
               triggerComplete(curFile);
             })
             .catch(() => {
-              curFile = { ...curFile, status: 'error' };
+              curFile = { ...curFile, status: Uploader3FileStatus.error };
               triggerComplete(curFile);
             });
         } else if (connector) {
@@ -118,11 +126,11 @@ export const Uploader3: React.FC<React.PropsWithChildren<Uploader3Props>> = ({
             .postImage(image)
             .then((result: { url: string; cid: string }) => {
               const { url, cid } = result;
-              curFile = { ...curFile, status: 'done', url, ipfs: 'ipfs://' + cid };
+              curFile = { ...curFile, status: Uploader3FileStatus.done, url, ipfs: 'ipfs://' + cid };
               triggerComplete(curFile);
             })
             .catch(() => {
-              curFile = { ...curFile, status: 'error' };
+              curFile = { ...curFile, status: Uploader3FileStatus.error };
               triggerComplete(curFile);
             });
         }
@@ -151,7 +159,7 @@ export const Uploader3: React.FC<React.PropsWithChildren<Uploader3Props>> = ({
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
     const files: SelectedFiles = acceptedFiles.map((file) => {
       const { name, type } = file;
-      return { name, type, file, previewUrl: URL.createObjectURL(file), status: 'none' };
+      return { name, type, file, previewUrl: URL.createObjectURL(file), status: Uploader3FileStatus.none };
     });
 
     setFiles(files);

--- a/packages/uploader3/src/Uploader3.tsx
+++ b/packages/uploader3/src/Uploader3.tsx
@@ -33,7 +33,7 @@ export const Uploader3: React.FC<React.PropsWithChildren<Uploader3Props>> = ({
   className,
   style,
   multiple = false,
-  accept = ['.jpg', '.jpeg', '.png', '.gif'],
+  accept = ['.jpg', '.jpeg', '.png', '.gif', '.svg'],
   api,
   crop = true,
   headers,
@@ -76,6 +76,8 @@ export const Uploader3: React.FC<React.PropsWithChildren<Uploader3Props>> = ({
       files.map(async (curFile: any) => {
         curFile = { ...curFile };
         curFile.status = 'uploading';
+        // when crop aspect ratio is  -1,
+        // the file will be uploaded directly. keep file type , eg: .svg
         if (!curFile.imageData) {
           curFile.imageData = await file2base64(curFile.file);
         }
@@ -202,6 +204,7 @@ export const Uploader3: React.FC<React.PropsWithChildren<Uploader3Props>> = ({
           show={showCrop}
           fileType={currentFile.type}
           fileUrl={currentFile.previewUrl!}
+          fileName={currentFile.name}
           onCancel={handleCancel}
           onConfirm={handleConfirm}
         />

--- a/packages/uploader3/src/UploaderCrop/index.tsx
+++ b/packages/uploader3/src/UploaderCrop/index.tsx
@@ -23,7 +23,7 @@ export type UploaderCroppProps = {
   fileType: string;
   fileName: string;
   show?: boolean;
-  onConfirm?: (options: { imageData: string | null; thumbData: string | null; cropData: Cropper.Data | null }) => void;
+  onConfirm?: (options: { imageData: string; thumbData: string; cropData: Cropper.Data | null }) => void;
   onCancel?: () => void;
 };
 
@@ -176,7 +176,7 @@ export const UploaderCrop: React.FC<UploaderCroppProps> = (props) => {
                     // No cropping of files with aspectRatio of 0
                     if (aspectRatio === 0 && fullSize) {
                       setCropping(false);
-                      props.onConfirm?.({ imageData: null, thumbData: null, cropData: null });
+                      props.onConfirm?.({ cropData: null, imageData: '', thumbData: '' });
                     } else {
                       const imageBase64 = cropper.getCroppedCanvas().toDataURL(fileType);
                       const thumbnailBase64 = cropper.getCroppedCanvas({ maxWidth: 600, maxHeight: 600 }).toDataURL();

--- a/packages/uploader3/src/UploaderCrop/index.tsx
+++ b/packages/uploader3/src/UploaderCrop/index.tsx
@@ -40,6 +40,7 @@ export const UploaderCrop: React.FC<UploaderCroppProps> = (props) => {
 
   const [cropping, setCropping] = useState(false);
   const [aspectRatio, setAspectRatio] = useState<number>(restProps.aspectRatio || 1);
+  const [fullSize, setFullSize] = useState<boolean>(false);
 
   const cropperOptions: Cropper.Options = useMemo(() => {
     return {
@@ -94,6 +95,16 @@ export const UploaderCrop: React.FC<UploaderCroppProps> = (props) => {
     },
     [cropperOptions]
   );
+
+  const updateAspectRatio = function (r: number, v?: number) {
+    if (fullSize) {
+      cropperRef.current?.enable();
+      setFullSize(false);
+    }
+    setAspectRatio(r);
+    cropperRef.current?.reset();
+    cropperRef.current?.setAspectRatio(v ?? r);
+  };
 
   return (
     <>
@@ -163,7 +174,7 @@ export const UploaderCrop: React.FC<UploaderCroppProps> = (props) => {
                 if (cropper) {
                   window.requestAnimationFrame(() => {
                     // No cropping of files with aspectRatio of 0
-                    if (aspectRatio === 0) {
+                    if (aspectRatio === 0 && fullSize) {
                       setCropping(false);
                       props.onConfirm?.({ imageData: null, thumbData: null, cropData: null });
                     } else {
@@ -193,9 +204,7 @@ export const UploaderCrop: React.FC<UploaderCroppProps> = (props) => {
             <Action
               active={16 / 9 === aspectRatio}
               onClick={() => {
-                setAspectRatio(16 / 9);
-                cropperRef.current?.reset();
-                cropperRef.current?.setAspectRatio(16 / 9);
+                updateAspectRatio(16 / 9);
               }}
             >
               <Ratio>16:9</Ratio>
@@ -203,9 +212,7 @@ export const UploaderCrop: React.FC<UploaderCroppProps> = (props) => {
             <Action
               active={4 / 3 === aspectRatio}
               onClick={() => {
-                setAspectRatio(4 / 3);
-                cropperRef.current?.reset();
-                cropperRef.current?.setAspectRatio(4 / 3);
+                updateAspectRatio(4 / 3);
               }}
             >
               <Ratio>4:3</Ratio>
@@ -213,9 +220,7 @@ export const UploaderCrop: React.FC<UploaderCroppProps> = (props) => {
             <Action
               active={1 === aspectRatio}
               onClick={() => {
-                setAspectRatio(1);
-                cropperRef.current?.reset();
-                cropperRef.current?.setAspectRatio(1);
+                updateAspectRatio(1);
               }}
             >
               <Ratio>1:1</Ratio>
@@ -223,22 +228,27 @@ export const UploaderCrop: React.FC<UploaderCroppProps> = (props) => {
             <Action
               active={2 / 3 === aspectRatio}
               onClick={() => {
-                setAspectRatio(2 / 3);
-                cropperRef.current?.reset();
-                cropperRef.current?.setAspectRatio(2 / 3);
+                updateAspectRatio(2 / 3);
               }}
             >
               <Ratio>2:3</Ratio>
             </Action>
             <Action
-              active={0 === aspectRatio}
+              active={0 === aspectRatio && !fullSize}
               onClick={() => {
-                setAspectRatio(0);
-                cropperRef.current?.reset();
-                cropperRef.current?.setAspectRatio(NaN);
+                updateAspectRatio(0, NaN);
               }}
             >
-              {/*<Icon icon={'iconoir:frame-simple'} />*/}
+              <Icon icon={'iconoir:frame-simple'} height={16} width={16} />
+            </Action>
+            <Action
+              active={fullSize}
+              onClick={() => {
+                updateAspectRatio(0, NaN);
+                setFullSize(true);
+                cropperRef.current?.disable();
+              }}
+            >
               <Ratio>full</Ratio>
             </Action>
           </ActionGroup>

--- a/packages/uploader3/src/UploaderCrop/index.tsx
+++ b/packages/uploader3/src/UploaderCrop/index.tsx
@@ -21,7 +21,7 @@ export type UploaderCroppProps = {
   aspectRatio?: number;
   fileUrl: string;
   fileType: string;
-  fileName: string;
+  fileName?: string;
   show?: boolean;
   onConfirm?: (options: { imageData: string; thumbData: string; cropData: Cropper.Data | null }) => void;
   onCancel?: () => void;
@@ -140,7 +140,7 @@ export const UploaderCrop: React.FC<UploaderCroppProps> = (props) => {
           }
         }}
       >
-        <div style={{ paddingBottom: '10px', color: 'var(--u3-text-color)' }}>{fileName}</div>
+        {fileName ? <div style={{ paddingBottom: '10px', color: 'var(--u3-text-color)' }}>{fileName}</div> : null}
         <CropperWrapper role={'cropper'}>
           <CroppCanvasWrapper size={size}>
             <CroppImage src={fileUrl} style={{ maxWidth: size.width, maxHeight: size.height }} ref={imageRef} />

--- a/packages/uploader3/src/UploaderCrop/ui.tsx
+++ b/packages/uploader3/src/UploaderCrop/ui.tsx
@@ -155,6 +155,6 @@ export const ActionGroup = styled.div`
 `;
 
 export const Icon = (props: IconProps) => {
-  let { style, ...restProps } = props;
-  return <IconifyIcon style={{ lineHeight: 0, fontSize: 20, height: 20, width: 20 }} {...restProps} />;
+  let { style, height = 20, width = 20, ...restProps } = props;
+  return <IconifyIcon style={{ lineHeight: 0 }} width={width} height={height} {...restProps} />;
 };

--- a/packages/uploader3/src/UploaderCrop/ui.tsx
+++ b/packages/uploader3/src/UploaderCrop/ui.tsx
@@ -23,6 +23,7 @@ export const CroppModal = styled.div<{ modalStatus: ModalStatus }>`
   --u3-action-bg-color: rgb(238, 238, 238);
   --u3-action-bg-color-active: rgb(228, 228, 228);
   --u3-action-text-color: rgb(90, 90, 90);
+  --u3-text-color: rgb(90, 90, 90);
   --u3-border-radius: 5px;
 
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3);
@@ -42,6 +43,7 @@ export const CroppModal = styled.div<{ modalStatus: ModalStatus }>`
     --u3-transparent-bg-color2: rgb(120, 120, 120);
     --u3-action-bg-color: rgb(74, 74, 74);
     --u3-action-bg-color-active: rgb(64, 64, 64);
+    --u3-text-color: rgb(180, 180, 180);
     --u3-action-text-color: rgb(180, 180, 180);
   }
 `;
@@ -53,7 +55,7 @@ export const CropperWrapper = styled.div`
   flex-direction: column;
 `;
 
-export const CroppCanvas = styled.div<Pick<UploaderCroppProps, 'size'>>`
+export const CroppCanvasWrapper = styled.div<Pick<UploaderCroppProps, 'size'>>`
   width: ${(props) => {
     if (typeof props.size?.width === 'number') {
       return props.size?.width + 'px';

--- a/packages/uploader3/src/__snapshots__/Uploader3.spec.tsx.snap
+++ b/packages/uploader3/src/__snapshots__/Uploader3.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`src/Uploader3.tsx should render Uploader3 1`] = `
       Upload
     </button>
     <input
-      accept="image/jpeg,.jpg,.jpeg,image/png,.png,image/gif,.gif"
+      accept="image/jpeg,.jpg,.jpeg,image/png,.png,image/gif,.gif,image/svg+xml,.svg"
       style="display: none;"
       tabindex="-1"
       type="file"

--- a/packages/uploader3/src/types.ts
+++ b/packages/uploader3/src/types.ts
@@ -4,6 +4,16 @@ import type { Uploader3Connector } from '@lxdao/uploader3-connector';
 
 export type ModalStatus = 'init' | 'show' | 'afterShow' | 'hide' | 'afterHide';
 
+export enum Uploader3FileStatus {
+  none = 'none',
+  cancel = 'cancel',
+  cropped = 'cropped',
+  notCropped = 'notCropped',
+  uploading = 'uploading',
+  done = 'done',
+  error = 'error',
+}
+
 export type SelectedFile = {
   /** The File object */
   file: File;
@@ -14,28 +24,28 @@ export type SelectedFile = {
   /** The file preview url of bold:// */
   previewUrl: string;
   /** file status */
-  status: 'none' | 'cancel';
+  status: Uploader3FileStatus.cancel | Uploader3FileStatus.none;
 };
 
 export type SelectedFiles = SelectedFile[];
 
 export type CroppedFile = Omit<SelectedFile, 'status'> & {
-  status: 'cropped';
+  status: Uploader3FileStatus.cropped | Uploader3FileStatus.notCropped;
   /** The cropp data */
   crop: Cropper.Data | null;
   /** Cropped preview data base64 type */
-  imageData: string | null;
+  imageData: string;
   /** Thumbnail preview data base64 type */
-  thumbData: string | null;
+  thumbData: string;
 };
 
 export type UploadFile = Omit<CroppedFile, 'status'> & {
-  status: 'uploading';
+  status: Uploader3FileStatus.uploading;
 };
 
 export type UploadResult =
-  | (Omit<UploadFile, 'status'> & { status: 'done'; url: string })
-  | (Omit<UploadFile, 'status'> & { status: 'error'; message: string });
+  | (Omit<UploadFile, 'status'> & { status: Uploader3FileStatus.done; url: string })
+  | (Omit<UploadFile, 'status'> & { status: Uploader3FileStatus.error; message: string });
 
 export type Uploader3Props = {
   children?: React.ReactNode;

--- a/packages/uploader3/src/types.ts
+++ b/packages/uploader3/src/types.ts
@@ -22,11 +22,11 @@ export type SelectedFiles = SelectedFile[];
 export type CroppedFile = Omit<SelectedFile, 'status'> & {
   status: 'cropped';
   /** The cropp data */
-  crop: Cropper.Data;
+  crop: Cropper.Data | null;
   /** Cropped preview data base64 type */
-  imageData: string;
+  imageData: string | null;
   /** Thumbnail preview data base64 type */
-  thumbData: string;
+  thumbData: string | null;
 };
 
 export type UploadFile = Omit<CroppedFile, 'status'> & {


### PR DESCRIPTION
1. default .svg format into accept
2. directly file (keep file mimeType) when aspectRotio is 0

If you choose a .svg file and want to keep the file mimeType and upload it directly, you can adjust the cropping ratio to `full`.

<img width="558" alt="image" src="https://github.com/lxdao-official/img3/assets/1292082/d1ca42f0-c43f-46e9-8098-9cb1ee5ad469">

